### PR TITLE
change UH site url to BCDAMS-MAP home page

### DIFF
--- a/public/_categories/university-of-houston.json
+++ b/public/_categories/university-of-houston.json
@@ -4,7 +4,7 @@
     "subtitle": "University of Houston Libraries",
     "tags": ["application-profile"],
     "about": "The University of Houston Libraries in Houston, Texas serve University of Houston students, faculty, staff, and the scholarly community.",
-    "site": "http://info.lib.uh.edu/",
+    "site": "https://vocab.lib.uh.edu/bcdams-map/",
     "image": "houston.jpg",
     "description": "Metadata guidelines created by the University of Houston Libraries.",
     "mappings": [


### PR DESCRIPTION
This might be a compromise solution to what we discussed earlier this year: https://github.com/scottythered/apclearing/pull/1
